### PR TITLE
Multi-sequence batching and automatic chunking for embeddings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ node_modules/
 dist/
 build/
 
+# clangd cache
+.cache/
+
 # Downloaded dependencies (cloned during postinstall)
 llama.cpp/
 

--- a/native/CMakeLists.txt
+++ b/native/CMakeLists.txt
@@ -4,6 +4,7 @@ project(llama_binding)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # Build llama.cpp as a static library
 set(LLAMA_STATIC ON CACHE BOOL "Build llama.cpp as static library" FORCE)
@@ -32,6 +33,16 @@ execute_process(
 )
 string(REPLACE "\"" "" NODE_ADDON_API_DIR ${NODE_ADDON_API_DIR})
 include_directories(${NODE_ADDON_API_DIR})
+
+# Find node-api-headers
+execute_process(
+    COMMAND node -p "require('node-api-headers').include_dir"
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE NODE_API_HEADERS_DIR
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+string(REPLACE "\"" "" NODE_API_HEADERS_DIR ${NODE_API_HEADERS_DIR})
+include_directories(${NODE_API_HEADERS_DIR})
 
 # Include llama.cpp headers
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../llama.cpp/include)

--- a/native/llama-wrapper.cpp
+++ b/native/llama-wrapper.cpp
@@ -1,6 +1,7 @@
 #include "llama-wrapper.h"
 #include "llama.h"
 #include <algorithm>
+#include <cassert>
 #include <cmath>
 #include <cstdio>
 #include <cstring>
@@ -17,6 +18,37 @@ static void llama_log_callback(ggml_log_level level, const char *text, void *use
   (void)user_data;
   if (g_debug_mode) {
     fprintf(stderr, "%s", text);
+  }
+}
+
+//
+// Batch utilities (adapted from llama.cpp/common/common.cpp)
+//
+
+// Reset batch token count for reuse
+static void batch_clear(llama_batch &batch) {
+  batch.n_tokens = 0;
+}
+
+// Add a single token to the batch with safety check
+static void batch_add(llama_batch &batch, llama_token id, llama_pos pos, llama_seq_id seq_id,
+                      bool logits) {
+  assert(batch.seq_id[batch.n_tokens] && "llama_batch size exceeded");
+
+  batch.token[batch.n_tokens] = id;
+  batch.pos[batch.n_tokens] = pos;
+  batch.n_seq_id[batch.n_tokens] = 1;
+  batch.seq_id[batch.n_tokens][0] = seq_id;
+  batch.logits[batch.n_tokens] = logits;
+
+  batch.n_tokens++;
+}
+
+// Add an entire sequence of tokens to the batch
+static void batch_add_seq(llama_batch &batch, const std::vector<int32_t> &tokens,
+                          llama_seq_id seq_id, bool logits) {
+  for (size_t i = 0; i < tokens.size(); i++) {
+    batch_add(batch, tokens[i], static_cast<llama_pos>(i), seq_id, logits);
   }
 }
 
@@ -110,14 +142,30 @@ bool LlamaModel::create_context(const ContextParams &params) {
   }
 
   llama_context_params ctx_params = llama_context_default_params();
-  ctx_params.n_ctx = params.n_ctx;
+
+  // Use model's training context size if not specified (0)
+  if (params.n_ctx > 0) {
+    ctx_params.n_ctx = params.n_ctx;
+  } else {
+    ctx_params.n_ctx = llama_model_n_ctx_train(model_);
+  }
+
   ctx_params.n_batch = params.n_batch;
   ctx_params.n_threads = params.n_threads;
   ctx_params.n_threads_batch = params.n_threads;
 
   if (params.embedding) {
     ctx_params.embeddings = true;
-    ctx_params.pooling_type = LLAMA_POOLING_TYPE_MEAN;
+    // UNSPECIFIED (-1) lets llama.cpp auto-detect from model metadata
+    ctx_params.pooling_type = static_cast<enum llama_pooling_type>(params.pooling_type);
+    // Utilize the full context
+    if (ctx_params.n_batch < ctx_params.n_ctx) {
+      ctx_params.n_batch = ctx_params.n_ctx;
+    }
+    // For encoder models (BERT, NomicBERT, etc.), n_ubatch must be >= n_tokens
+    // for each decode call. Set n_ubatch = n_batch to support processing all
+    // tokens at once. See: https://github.com/ggml-org/llama.cpp/issues/12836
+    ctx_params.n_ubatch = ctx_params.n_batch;
   }
 
   ctx_ = llama_init_from_model(model_, ctx_params);
@@ -137,7 +185,149 @@ void LlamaModel::normalize_embedding(float *embedding, int n_embd) {
   }
 }
 
-EmbeddingResult LlamaModel::embed(const std::vector<std::string> &texts) {
+bool LlamaModel::is_encoder_model() const {
+  if (!model_) {
+    return false;
+  }
+
+  // Get the model architecture from GGUF metadata
+  char arch[128];
+  if (llama_model_meta_val_str(model_, "general.architecture", arch, sizeof(arch)) <= 0) {
+    return false; // Can't determine, assume decoder
+  }
+
+  // Check 1: Explicit non-causal attention (e.g., BERT models)
+  // Build the key: e.g., "nomic-bert.attention.causal"
+  std::string causal_key = std::string(arch) + ".attention.causal";
+  char causal_val[16];
+
+  if (llama_model_meta_val_str(model_, causal_key.c_str(), causal_val, sizeof(causal_val)) > 0) {
+    // "false" means non-causal attention (encoder model)
+    if (strcmp(causal_val, "false") == 0) {
+      return true;
+    }
+  }
+
+  // Check 2: Explicit pooling type in GGUF metadata indicates an embedding model
+  // (e.g., Qwen3-Embedding has pooling_type set but no attention.causal metadata)
+  // Embedding models generally don't support multi-sequence batching well
+  std::string pooling_key = std::string(arch) + ".pooling_type";
+  char pooling_val[16];
+
+  if (llama_model_meta_val_str(model_, pooling_key.c_str(), pooling_val, sizeof(pooling_val)) > 0) {
+    // If pooling_type is explicitly set in model metadata, treat as embedding model
+    // pooling_type > 0 means MEAN, CLS, LAST, or RANK pooling (not NONE)
+    int pooling_type = atoi(pooling_val);
+    if (pooling_type > 0) {
+      return true;
+    }
+  }
+
+  return false; // Default to decoder if metadata not found
+}
+
+std::vector<float> LlamaModel::embed_chunk(const std::vector<int32_t> &tokens, int seq_id,
+                                           int n_embd, int pooling_type) {
+  std::vector<float> embedding(n_embd, 0.0f);
+
+  if (tokens.empty()) {
+    return embedding;
+  }
+
+  // Clear the memory/KV cache
+  llama_memory_t mem = llama_get_memory(ctx_);
+  if (mem) {
+    llama_memory_clear(mem, true);
+  }
+
+  // Create batch with sequence ID
+  llama_batch batch = llama_batch_init(tokens.size(), 0, 1);
+  batch_add_seq(batch, tokens, seq_id, false); // Embeddings don't need logits
+
+  // Decode to get embeddings
+  if (llama_decode(ctx_, batch) != 0) {
+    llama_batch_free(batch);
+    throw std::runtime_error("llama_decode failed during embedding");
+  }
+
+  // Extract embedding based on pooling type
+  const float *embd = nullptr;
+  if (static_cast<enum llama_pooling_type>(pooling_type) == LLAMA_POOLING_TYPE_NONE) {
+    // Get embedding for last token
+    embd = llama_get_embeddings_ith(ctx_, tokens.size() - 1);
+  } else {
+    // Get pooled embedding for the sequence
+    embd = llama_get_embeddings_seq(ctx_, seq_id);
+  }
+
+  if (embd) {
+    std::copy(embd, embd + n_embd, embedding.begin());
+  }
+
+  llama_batch_free(batch);
+  return embedding;
+}
+
+std::vector<std::vector<float>>
+LlamaModel::embed_batch(const std::vector<std::vector<int32_t>> &all_tokens, int n_embd,
+                        int pooling_type) {
+  std::vector<std::vector<float>> embeddings;
+
+  if (all_tokens.empty()) {
+    return embeddings;
+  }
+
+  // Calculate total tokens needed
+  size_t total_tokens = 0;
+  for (const auto &tokens : all_tokens) {
+    total_tokens += tokens.size();
+  }
+
+  // Clear the memory/KV cache
+  llama_memory_t mem = llama_get_memory(ctx_);
+  if (mem) {
+    llama_memory_clear(mem, true);
+  }
+
+  // Create batch for all sequences
+  llama_batch batch = llama_batch_init(total_tokens, 0, all_tokens.size());
+  for (size_t seq_id = 0; seq_id < all_tokens.size(); seq_id++) {
+    batch_add_seq(batch, all_tokens[seq_id], static_cast<llama_seq_id>(seq_id), false);
+  }
+
+  // Decode all sequences at once
+  if (llama_decode(ctx_, batch) != 0) {
+    llama_batch_free(batch);
+    throw std::runtime_error("llama_decode failed during batch embedding");
+  }
+
+  // Extract embeddings for each sequence
+  for (size_t seq_id = 0; seq_id < all_tokens.size(); seq_id++) {
+    std::vector<float> embedding(n_embd, 0.0f);
+
+    const float *embd = nullptr;
+    if (static_cast<enum llama_pooling_type>(pooling_type) == LLAMA_POOLING_TYPE_NONE) {
+      // For NONE pooling, we need to find the last token of this sequence
+      // This is more complex in batched mode, fall back to sequence embedding
+      embd = llama_get_embeddings_seq(ctx_, seq_id);
+    } else {
+      // Get pooled embedding for the sequence
+      embd = llama_get_embeddings_seq(ctx_, seq_id);
+    }
+
+    if (embd) {
+      std::copy(embd, embd + n_embd, embedding.begin());
+    }
+
+    embeddings.push_back(std::move(embedding));
+  }
+
+  llama_batch_free(batch);
+  return embeddings;
+}
+
+EmbeddingResult LlamaModel::embed(const std::vector<std::string> &texts,
+                                  const EmbedParams &params) {
   EmbeddingResult result;
   result.total_tokens = 0;
 
@@ -145,68 +335,138 @@ EmbeddingResult LlamaModel::embed(const std::vector<std::string> &texts) {
     return result;
   }
 
-  const int n_embd = llama_model_n_embd(model_);
+  // Verify embedding mode is enabled
   const enum llama_pooling_type pooling_type = llama_pooling_type(ctx_);
+  if (pooling_type == LLAMA_POOLING_TYPE_UNSPECIFIED) {
+    throw std::runtime_error("Context not configured for embeddings");
+  }
 
-  // Process each text
-  for (size_t seq_id = 0; seq_id < texts.size(); seq_id++) {
-    const std::string &text = texts[seq_id];
+  const int n_embd = llama_model_n_embd(model_);
+  const int n_ctx = llama_n_ctx(ctx_);
+  // Clamp overlap to [0, n_ctx - 1] to prevent negative or zero step (infinite loop)
+  const int raw_overlap = static_cast<int>(n_ctx * params.overlap);
+  const int overlap = std::max(0, std::min(raw_overlap, n_ctx - 1));
+  const int step = n_ctx - overlap;
 
-    // Tokenize the text
-    std::vector<int32_t> tokens = tokenize(text, true);
+  // Auto-detect BOS token preference from model metadata
+  const llama_vocab *vocab = llama_model_get_vocab(model_);
+  const bool add_bos = llama_vocab_get_add_bos(vocab);
+
+  // First pass: tokenize all texts and check if batching is possible
+  std::vector<std::vector<int32_t>> all_tokens;
+  std::vector<size_t> long_text_indices; // Indices of texts that need chunking
+  size_t total_short_tokens = 0;
+
+  for (size_t i = 0; i < texts.size(); i++) {
+    std::vector<int32_t> tokens = tokenize(texts[i], add_bos);
     result.total_tokens += tokens.size();
 
-    if (tokens.empty()) {
-      // Return zero embedding for empty text
-      result.embeddings.push_back(std::vector<float>(n_embd, 0.0f));
-      continue;
+    if (static_cast<int>(tokens.size()) > n_ctx) {
+      long_text_indices.push_back(i);
+    } else if (!tokens.empty()) {
+      total_short_tokens += tokens.size();
     }
 
-    // Clear the memory/KV cache
-    llama_memory_t mem = llama_get_memory(ctx_);
-    if (mem) {
-      llama_memory_clear(mem, true);
-    }
+    all_tokens.push_back(std::move(tokens));
+  }
 
-    // Create batch with sequence ID
-    llama_batch batch = llama_batch_init(tokens.size(), 0, 1);
-    for (size_t i = 0; i < tokens.size(); i++) {
-      batch.token[i] = tokens[i];
-      batch.pos[i] = i;
-      batch.n_seq_id[i] = 1;
-      batch.seq_id[i][0] = seq_id;
-      batch.logits[i] = true; // We want embeddings for all tokens
-    }
-    batch.n_tokens = tokens.size();
+  // Determine if we can batch all short texts using multi-sequence batching.
+  // Multi-sequence batching (different seq_ids for each text) only works reliably for
+  // decoder (causal) models.
+  bool can_batch = !is_encoder_model() && long_text_indices.empty() &&
+                   total_short_tokens <= static_cast<size_t>(n_ctx);
 
-    // Decode to get embeddings
-    if (llama_decode(ctx_, batch) != 0) {
-      llama_batch_free(batch);
-      result.embeddings.push_back(std::vector<float>(n_embd, 0.0f));
-      continue;
-    }
+  if (can_batch) {
+    // Fast path: batch all short texts in a single decode call
+    try {
+      // Filter out empty texts for batching
+      std::vector<std::vector<int32_t>> non_empty_tokens;
+      std::vector<size_t> non_empty_indices;
 
-    // Extract embedding based on pooling type
-    const float *embd = nullptr;
-    if (pooling_type == LLAMA_POOLING_TYPE_NONE) {
-      // Get embedding for last token
-      embd = llama_get_embeddings_ith(ctx_, tokens.size() - 1);
-    } else {
-      // Get pooled embedding for the sequence
-      embd = llama_get_embeddings_seq(ctx_, seq_id);
-    }
+      for (size_t i = 0; i < all_tokens.size(); i++) {
+        if (!all_tokens[i].empty()) {
+          non_empty_tokens.push_back(all_tokens[i]);
+          non_empty_indices.push_back(i);
+        }
+      }
 
-    if (embd) {
-      std::vector<float> embedding(n_embd);
-      std::copy(embd, embd + n_embd, embedding.begin());
-      // Normalize the embedding (L2 normalization)
-      normalize_embedding(embedding.data(), n_embd);
-      result.embeddings.push_back(std::move(embedding));
-    } else {
-      result.embeddings.push_back(std::vector<float>(n_embd, 0.0f));
-    }
+      std::vector<std::vector<float>> batch_embeddings;
+      if (!non_empty_tokens.empty()) {
+        batch_embeddings = embed_batch(non_empty_tokens, n_embd, pooling_type);
+      }
 
-    llama_batch_free(batch);
+      // Reconstruct results in original order
+      size_t batch_idx = 0;
+      for (size_t i = 0; i < all_tokens.size(); i++) {
+        if (all_tokens[i].empty()) {
+          result.embeddings.push_back(std::vector<float>(n_embd, 0.0f));
+        } else {
+          auto &emb = batch_embeddings[batch_idx++];
+          if (params.normalize) {
+            normalize_embedding(emb.data(), n_embd);
+          }
+          result.embeddings.push_back(std::move(emb));
+        }
+      }
+    } catch (const std::runtime_error &e) {
+      throw std::runtime_error(std::string("Failed to batch embed: ") + e.what());
+    }
+  } else {
+    // Slow path: process each text individually (some need chunking or won't fit in batch)
+    // Use seq_id=0 for all texts since we clear the cache between each text
+    const int seq_id = 0;
+    for (size_t text_idx = 0; text_idx < texts.size(); text_idx++) {
+      const auto &tokens = all_tokens[text_idx];
+
+      if (tokens.empty()) {
+        result.embeddings.push_back(std::vector<float>(n_embd, 0.0f));
+        continue;
+      }
+
+      try {
+        if (static_cast<int>(tokens.size()) <= n_ctx) {
+          // Process single chunk
+          std::vector<float> embedding = embed_chunk(tokens, seq_id, n_embd, pooling_type);
+          if (params.normalize) {
+            normalize_embedding(embedding.data(), n_embd);
+          }
+          result.embeddings.push_back(std::move(embedding));
+        } else {
+          // Text exceeds context size - split into overlapping chunks
+          std::vector<float> final_embedding(n_embd, 0.0f);
+          int num_chunks = 0;
+
+          for (size_t start = 0; start < tokens.size(); start += step) {
+            size_t end = std::min(start + n_ctx, tokens.size());
+            std::vector<int32_t> chunk_tokens(tokens.begin() + start, tokens.begin() + end);
+
+            std::vector<float> chunk_emb = embed_chunk(chunk_tokens, seq_id, n_embd, pooling_type);
+            for (int i = 0; i < n_embd; i++) {
+              final_embedding[i] += chunk_emb[i];
+            }
+            num_chunks++;
+
+            if (end == tokens.size()) {
+              break;
+            }
+          }
+
+          if (num_chunks > 0) {
+            for (int i = 0; i < n_embd; i++) {
+              final_embedding[i] /= static_cast<float>(num_chunks);
+            }
+          }
+
+          if (params.normalize) {
+            normalize_embedding(final_embedding.data(), n_embd);
+          }
+          result.embeddings.push_back(std::move(final_embedding));
+        }
+      } catch (const std::runtime_error &e) {
+        throw std::runtime_error(std::string("Failed to embed text at index ") +
+                                 std::to_string(text_idx) + ": " + e.what());
+      }
+    }
   }
 
   return result;

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,10 @@ export {
   convertFinishReason,
   convertUsage,
 } from "./llama-cpp-language-model.js";
-export { LlamaCppEmbeddingModel } from "./llama-cpp-embedding-model.js";
+export {
+  LlamaCppEmbeddingModel,
+  type LlamaCppEmbeddingModelConfig,
+} from "./llama-cpp-embedding-model.js";
 
 // Export JSON schema to grammar converter for advanced use cases
 export {

--- a/src/llama-cpp-embedding-model.ts
+++ b/src/llama-cpp-embedding-model.ts
@@ -15,6 +15,30 @@ import {
 } from "./native-binding.js";
 import type { LlamaCppProviderConfig } from "./llama-cpp-provider.js";
 
+export interface LlamaCppEmbeddingModelConfig extends LlamaCppProviderConfig {
+  /**
+   * Pooling type for embeddings (only applies to embedding models).
+   * If not specified, auto-detects from the model's GGUF metadata.
+   * - "none": Use last token embedding
+   * - "mean": Average all token embeddings
+   * - "cls": Use first token embedding (CLS token)
+   * - "last": Use last token embedding
+   */
+  poolingType?: "none" | "mean" | "cls" | "last";
+
+  /**
+   * Whether to L2 normalize embeddings (default: true).
+   * Set to true for cosine similarity, false for dot product.
+   */
+  normalize?: boolean;
+
+  /**
+   * Overlap fraction for chunking long texts (default: 0.1 = 10%).
+   * Used when text exceeds the context size.
+   */
+  overlap?: number;
+}
+
 export class LlamaCppEmbeddingModel implements EmbeddingModelV3 {
   readonly specificationVersion = "v3" as const;
   readonly provider = "llama.cpp";
@@ -33,12 +57,27 @@ export class LlamaCppEmbeddingModel implements EmbeddingModelV3 {
   readonly supportsParallelCalls: boolean = false;
 
   private modelHandle: number | null = null;
-  private readonly config: LlamaCppProviderConfig;
+  private readonly config: LlamaCppEmbeddingModelConfig;
   private initPromise: Promise<void> | null = null;
 
-  constructor(config: LlamaCppProviderConfig) {
+  constructor(config: LlamaCppEmbeddingModelConfig) {
     this.config = config;
     this.modelId = config.modelPath;
+  }
+
+  private getPoolingTypeNumber(): number {
+    switch (this.config.poolingType) {
+      case "none":
+        return 0;
+      case "mean":
+        return 1;
+      case "cls":
+        return 2;
+      case "last":
+        return 3;
+      default:
+        return -1; // UNSPECIFIED: auto-detect from model metadata
+    }
   }
 
   private async ensureModelLoaded(): Promise<number> {
@@ -56,11 +95,12 @@ export class LlamaCppEmbeddingModel implements EmbeddingModelV3 {
     this.initPromise = (async () => {
       const options: LoadModelOptions = {
         modelPath: this.config.modelPath,
-        contextSize: this.config.contextSize ?? 2048,
+        contextSize: this.config.contextSize ?? 0,
         gpuLayers: this.config.gpuLayers ?? 99,
         threads: this.config.threads ?? 4,
         debug: this.config.debug ?? false,
         embedding: true,
+        poolingType: this.getPoolingTypeNumber(),
       };
 
       this.modelHandle = await loadModel(options);
@@ -80,6 +120,10 @@ export class LlamaCppEmbeddingModel implements EmbeddingModelV3 {
    * Dispose of the model and free resources.
    */
   async dispose(): Promise<void> {
+    // Wait for any pending initialization to complete
+    if (this.initPromise) {
+      await this.initPromise;
+    }
     if (this.modelHandle !== null) {
       unloadModel(this.modelHandle);
       this.modelHandle = null;
@@ -93,6 +137,8 @@ export class LlamaCppEmbeddingModel implements EmbeddingModelV3 {
 
     const embedOptions: EmbedOptions = {
       texts: options.values,
+      normalize: this.config.normalize ?? true,
+      overlap: this.config.overlap ?? 0.1,
     };
 
     const result = await embed(handle, embedOptions);

--- a/src/llama-cpp-language-model.ts
+++ b/src/llama-cpp-language-model.ts
@@ -178,7 +178,7 @@ export class LlamaCppLanguageModel implements LanguageModelV3 {
     this.initPromise = (async () => {
       const options: LoadModelOptions = {
         modelPath: this.config.modelPath,
-        contextSize: this.config.contextSize ?? 2048,
+        contextSize: this.config.contextSize ?? 0,
         gpuLayers: this.config.gpuLayers ?? 99,
         threads: this.config.threads ?? 4,
         debug: this.config.debug ?? false,

--- a/src/llama-cpp-provider.ts
+++ b/src/llama-cpp-provider.ts
@@ -2,7 +2,10 @@ import {
   LlamaCppLanguageModel,
   type LlamaCppModelConfig,
 } from "./llama-cpp-language-model.js";
-import { LlamaCppEmbeddingModel } from "./llama-cpp-embedding-model.js";
+import {
+  LlamaCppEmbeddingModel,
+  type LlamaCppEmbeddingModelConfig,
+} from "./llama-cpp-embedding-model.js";
 
 export interface LlamaCppProviderConfig {
   /**
@@ -11,7 +14,8 @@ export interface LlamaCppProviderConfig {
   modelPath: string;
 
   /**
-   * Maximum context size (default: 2048).
+   * Maximum context size.
+   * If not specified (or 0), uses the model's training context size from GGUF metadata.
    */
   contextSize?: number;
 
@@ -22,7 +26,7 @@ export interface LlamaCppProviderConfig {
   gpuLayers?: number;
 
   /**
-   * Number of CPU threads to use (default2: 4).
+   * Number of CPU threads to use (default: 4).
    */
   threads?: number;
 
@@ -33,13 +37,13 @@ export interface LlamaCppProviderConfig {
 }
 
 export interface LlamaCppProvider {
-  (config: LlamaCppProviderConfig): LlamaCppLanguageModel;
-  languageModel(config: LlamaCppProviderConfig): LlamaCppLanguageModel;
-  embedding(config: LlamaCppProviderConfig): LlamaCppEmbeddingModel;
+  (config: LlamaCppModelConfig): LlamaCppLanguageModel;
+  languageModel(config: LlamaCppModelConfig): LlamaCppLanguageModel;
+  embedding(config: LlamaCppEmbeddingModelConfig): LlamaCppEmbeddingModel;
 }
 
 function createLlamaCpp(): LlamaCppProvider {
-  const provider = (config: LlamaCppProviderConfig): LlamaCppLanguageModel => {
+  const provider = (config: LlamaCppModelConfig): LlamaCppLanguageModel => {
     const modelConfig: LlamaCppModelConfig = {
       modelPath: config.modelPath,
       contextSize: config.contextSize,
@@ -53,7 +57,7 @@ function createLlamaCpp(): LlamaCppProvider {
 
   provider.languageModel = provider;
 
-  provider.embedding = (config: LlamaCppProviderConfig) => {
+  provider.embedding = (config: LlamaCppEmbeddingModelConfig) => {
     return new LlamaCppEmbeddingModel(config);
   };
 

--- a/src/native-binding.ts
+++ b/src/native-binding.ts
@@ -24,10 +24,19 @@ export interface LoadModelOptions {
   chatTemplate?: string;
   /**
    * Whether to load the model for embedding generation.
-   * When true, creates an embedding context with mean pooling enabled.
+   * When true, creates an embedding context with pooling enabled.
    * Default: false
    */
   embedding?: boolean;
+  /**
+   * Pooling type for embeddings.
+   * - -1: UNSPECIFIED (auto-detect from model metadata, default)
+   * - 0: NONE (use last token embedding)
+   * - 1: MEAN (average all token embeddings)
+   * - 2: CLS (use first token embedding)
+   * - 3: LAST (use last token embedding)
+   */
+  poolingType?: number;
 }
 
 export interface ChatMessage {
@@ -55,6 +64,16 @@ export interface GenerateResult {
 
 export interface EmbedOptions {
   texts: string[];
+  /**
+   * Whether to L2 normalize embeddings (default: true).
+   * Set to true for cosine similarity, false for dot product.
+   */
+  normalize?: boolean;
+  /**
+   * Overlap fraction for chunking long texts (default: 0.1 = 10%).
+   * Used when text exceeds the context size.
+   */
+  overlap?: number;
 }
 
 export interface EmbedResult {

--- a/tests/e2e/generation.test.ts
+++ b/tests/e2e/generation.test.ts
@@ -29,7 +29,7 @@ describeE2E("E2E Generation Tests", () => {
     model = llamaCpp({
       modelPath: TEST_MODEL_PATH,
       contextSize: 2048,
-      gpuLayers: 0, // Use CPU for CI compatibility
+      gpuLayers: process.env.CI ? 0 : 99, // Use CPU for CI compatibility
       threads: 4,
     });
   });

--- a/tests/integration/language-model.test.ts
+++ b/tests/integration/language-model.test.ts
@@ -121,7 +121,7 @@ describe("LlamaCppLanguageModel Integration", () => {
         prompt: testMessages,
       });
 
-      expect(result.request.body).toHaveProperty("maxTokens", 256);
+      expect(result.request.body).toHaveProperty("maxTokens", 2048);
     });
 
     it("applies default temperature when not specified", async () => {
@@ -373,7 +373,7 @@ describe("LlamaCppLanguageModel Integration", () => {
 
       expect(nativeBinding.loadModel).toHaveBeenCalledWith({
         modelPath: "/minimal.gguf",
-        contextSize: 2048,
+        contextSize: 0,
         gpuLayers: 99,
         threads: 4,
         debug: false,


### PR DESCRIPTION
## Changes

- Adds support for multi-sequence batching when embed input texts are small enough to fit in context
- Adds support for automatic chunking when embed text is larger than the context size
- Chunks are averaged to produce a final embedding
- Configurable `overlap` between chunks (default: 10%)
- Uses GGUF metadata for configuring defaults (and detecting decoder models)

### Configuration Options

- `contextSize`: defaults to context size defined in GGUF metadata
- `poolingType`: Explicitly set pooling strategy ("none" | "mean" | "cls" | "last"), defaults to GGUF metadata
- `normalize`: Control L2 normalization of embeddings (default: true for cosine similarity)
- `overlap`: Set overlap between chunks of texts (default: 0.1)

### Build

- Enabled `CMAKE_EXPORT_COMPILE_COMMANDS` for clangd integration
- Added `node-api-headers` include directory to fix my IDE errors

## Breaking Changes

- `contextSize` default changed from 2048 to 0 (auto-detect from model)
- `poolingType` default changed from hardcoded MEAN to auto-detect from model metadata
